### PR TITLE
Updates related to template repositories

### DIFF
--- a/IO-site/admin-guide/iTC-Workflow.adoc
+++ b/IO-site/admin-guide/iTC-Workflow.adoc
@@ -1,0 +1,80 @@
+= iTC Workflow Overview
+:showtitle:
+:toc:
+:toclevels: 7
+:sectnums:
+:sectnumlevels: 7
+:imagesdir: images
+:icons: font
+:revnumber: 0.1
+:revdate: 2019-08-01
+
+include::menu-include.adoc[]
+
+:sectnums!:
+
+== Acknowledgements
+This is a quick overview of some of the Working Group and iTC management processes related to the tools that are provided here.
+
+This document intends to communicate to the WG/iTC admins some of the tools that can be used and when they may be most beneficial. This is not intended to be a replacement for iTC guidance from the CCDB, but some assistance as to how/when to use the tools provided here.
+
+== Audience
+The intended audience for this overview are those people who will manage the technical processes of the WG/iTC. This may be the chair or other representative.
+
+[IMPORTANT]
+====
+This page is not intended to replace the link:index.html[Admin Guide], but only to provide some pointers about using the repositories.
+====
+
+== Resources
+* link:index.html[iTC Administrator Tools Overview]
+* https://www.commoncriteriaportal.org/files/communities/Establishing%20iTCs%20and%20cPP%20development%20-%20v0-7.pdf[Establishing iTCs and cPP development, window=\"_blank\"]
+
+:sectnums:
+== Introduction
+Generally an iTC should end up with at least three repositories for their work. Note that the name here is meant as a descriptive name, and does not need to be the actual name of the repository that is created.
+
+.Repositories
+[cols=".^1,.^2",options="header"]
+|===
+|Name
+|Description
+
+|iTC Admin
+|This repository would contain the governing documents for the WG/iTC. For example there is an ESR template that could be used in the template repository. 
+
+|iTC website
+|This repository would be used for the github.io website that can be setup for the WG/iTC. This would provide a place for the group to announce the status and progress of the group.
+
+|iTC Docs
+|This repository would contain the cPP, SD and PP-Configuration (and PP-Module if needed). This would be the main working folder for the output of the iTC (as opposed to the administration of the iTC).
+
+|===
+
+== Repositories and the Workflow
+The three repositories are useful at different times in the creation and ongoing support of an iTC, and can be used as such. There is no requirement that all the repositories be created at once, GitHub allows the creation of repositories at any time within the organization, enabling it to change over time.
+
+With that in mind, here are some recommendations about when it may be useful to create the various repositories based on the current "Establishing iTCs and cPP development" document.
+
+.Workflow Points for Creating Repositories
+[cols=".^1,.^1,2",options="header"]
+|===
+|Process Flow Period
+|Repository to Create (Template link)
+|Description
+
+|CCDB creates WG (block 4)
+|https://github.com/itc-wgtools/New-iTC-Admin-template[iTC Admin Repository,window=\"_blank\"]
+|At this point the WG has been created and work on the initial documents must start. Templates for these documents are available in this template repository.
+
+|Any time between CCDB creates WG and iTC creates draft SPD (blocks 4 to 14)
+|https://github.com/itc-wgtools/New-iTC-website-Template[iTC website,window=\"_blank\"]
+|The creation of the website can happen at any point, even later than the beginning of the SPD work, but it would seem a good idea to provide more information about what is going on (and the ability to control the format of the information) than is available on the CC Portal.
+
+|iTC creates draft SPD (block 14)
+|https://github.com/itc-wgtools/New-iTC-Template[iTC Docs,window=\"_blank\"]
+|The start of work on the SPD is really the first place where the cPP work starts, so at this point the cPP repository should be created.
+
+|===
+
+A key assumption here is that the people in the WG will also be part of the eventual iTC, so there would be a smooth transition from one phase to the next, and the repositories would provide a history of everything from the initial ESR work onwards.

--- a/IO-site/admin-guide/index.adoc
+++ b/IO-site/admin-guide/index.adoc
@@ -32,6 +32,8 @@ Ideally the person who is responsible for GitHub should be someone familiar with
 * link:GitHubio.html[Publishing the iTC GitHub Website]
 * link:AsciidoctorPublish.html[Asciidoctor Generating Output]
 * link:DocPublishing.html[Publishing iTC Documents]
+* link:iTC-Workflow.html[iTC Workflow]
+* https://github.com/itc-wgtools/repo-labels[repo-labels repository]
 
 :sectnums:
 == Introduction
@@ -55,16 +57,63 @@ By using GitHub as the central repository, many of the problems with collaborati
 The steps here assume that the person who will manage the GitHub repository already has a GitHub account (a free account is sufficient).
 ====
 
-To setup the iTC organization and repository, do the following:
+==== Organization Setup
+To setup the iTC organization, do the following:
 
 . Login to https://github.com with your account
 . Choose what the iTC group's Organization and Repositories should be named
 . Click the down arrow in the upper right corner of the page next to the user icon
 . Click "New Organization", and enter the agreed on Organization name
 .. Select the "My personal account" option for the owner of the new Organization
-. Click "Your repositories", and then click New in the upper right quadrant of the screen
-. Choose the Organization as the owner (it will default to your account) and enter the Respository name, add a description if necessary, and finally click Create repository. The rest can be left as default
+
+==== Repository Setup
+Once you have created the organization, you need to create some repositories. The number needed may depend on where you are in the process. Three template repositories have been created to help create the structure and populate the initial templates you need.
+
+.Template Repositories
+[cols=".^1,.^2,2",options="header"]
+|===
+|Name
+|Description
+|URL
+
+|New-iTC-Admin-template
+|This contains templates for the iTC such as the ESR, ToR and other governing documents.
+|https://github.com/itc-wgtools/New-iTC-Admin-template[,window=\"_blank\"]
+
+|New-iTC-Template
+|This contains templates for the cPP, SD and PP-Configuration (and PP-Module if needed)
+|https://github.com/itc-wgtools/New-iTC-Template[,window=\"_blank\"]
+
+|New-iTC-website-template
+|This contains a template for the github.io website that can be setup for the iTC
+|https://github.com/itc-wgtools/New-iTC-website-template[,window=\"_blank\"]
+
+|===
+
+All three templates should be used when setting up the iTC, though it is possible that some may be used at different times (see link:./iTC-workflow.html[iTC Workflow]).
+
+Each template uses the same steps to do the initial setup of your new repository.
+
+To create the new repository, follow these steps:
+
+. Go to the URL for the type of repository you are going to create
+. Click the green "Use this template" button
+. Choose the Organization as the owner (it will default to your account) and enter the Respository name, add a description if necessary, and finally click Create repository from template. The rest can be left as default
 . The next screen after creation is useful for getting up and running. Read the Quick setup steps, commands used, etc.
+
+===== New-iTC-Template repo-labels script
+[IMPORTANT]
+====
+This section is only needed when creating a repository for the cPP and related documents. While it can be used for any of the repositories, the labels created are only needed in the cPP repository.
+====
+
+When the creating the cPP repository from the New-iTC-Template repository, it is important to run the script contained in the https://github.com/itc-wgtools/repo-labels[repo-labels] repository. The purpose of this script is to edit the labels available for Issues and Pull Requests to a standard set (and be relied upon for other tools added over time).
+
+While the repository will work fine without this script, some of the features of the template repository and some planned maintenance tools will not work correctly without this script.
+
+Instructions for running the script are at the repository.
+
+The repository assumes the user has installed Ruby (such as by following <<Installing Ruby>>). 
 
 === Organization Settings
 ==== Organization Owners

--- a/IO-site/admin-guide/menu-include.adoc
+++ b/IO-site/admin-guide/menu-include.adoc
@@ -4,11 +4,12 @@
 :home: ../index.html[Home]
 :admin: ../admin-guide/index.html[Admin Guide]
 :user: ../user-guide/index.html[User Guide]
+:itcwork: ../admin-guide/iTC-Workflow.html[iTC Workflow]
 :drafts: ../drafts/index.html[Drafts]
 :examples: ../examples/examples.html[Examples]
 
 // Create the menu as an Asciidoctor table
 [.main-menu]
 |===
-|link:{home}|link:{admin}|link:{user}|link:{drafts}|link:{examples}
+|link:{home}|link:{admin}|link:{user}|link:{itcwork}|link:{drafts}|link:{examples}
 |===


### PR DESCRIPTION
This is a set of updates to the web pages related to using the template repositories to setup the iTC workspace. This is an adjustment from the previous which had blank (i.e. they create a blank set).

I have also added a new page that talks about when to create these repositories (since they don't NEED to be done all at the same time).